### PR TITLE
Added quotes around peer name

### DIFF
--- a/src/rtt_dot_service.cpp
+++ b/src/rtt_dot_service.cpp
@@ -337,7 +337,7 @@ bool Dot::execute()
         case base::TaskCore::RunTimeError  : st_str = "RunTimeError  ";color = "red";         break;
     }
 
-    m_dot << mpeer << "[shape=record,fillcolor=\""<<color<<"\",label=\"\\N|{{";
+    m_dot << quote(mpeer) << "[shape=record,fillcolor=\""<<color<<"\",label=\"\\N|{{";
     int current_count = 0;
     buildComponentInputPortsMap("",tc->provides(),current_count);
     m_dot << " } | | { ";


### PR DESCRIPTION
In case peer names contain a slash "/"  an error is produced
`Error: <stdin>: syntax error in line 9 near '/'`

this can be fixed by putting quotes around the peer name